### PR TITLE
Update LICENSE with code-input Upstream Copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2024 Melvin Bagnes ( Java Architect | Collabera Digital Tech )
+Copyright (c) 2021-2023 WebCoder49
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Hello, @melvinbagnes ! It's good to see that my code-input library is popular enough for you to want to fork it - GitHub notified me.

It's licensed under the permissive MIT license, which offers you a lot of freedom with how you can use the software. However, this **includes the requirement that you keep my copyright notice and license of code-input here in your fork**, as well as your own. Please could you add my copyright statement to the LICENSE file to meet these terms, [as per this Gist](https://gist.github.com/fbaierl/1d740a7925a6e0e608824eb27a429370)? (You can do this more quickly by **just merging this pull request**).

---

* I understand that this might have just been an oversight - if so, please don't worry; it's extremely simple to fix. Also, if you have any questions about how code-input works / want to point out bugs / suggest new features, please just let me know [via code-input with Issues](https://github.com/WebCoder49/code-input/issues) (and optionally Pull Requests). I'm rather busy now, but near the end of May will be able to start responding and developing properly.

* The paragraph in the license that requires this is:
> The above copyright notice and this permission notice shall be included in all
> copies or substantial portions of the Software.

* GitHub provides more information on the MIT license [here](https://choosealicense.com/licenses/mit/).

